### PR TITLE
Resolves #10, Add version flag -V, --version or -v with no other arguments

### DIFF
--- a/bin/asciidoctorjs
+++ b/bin/asciidoctorjs
@@ -116,20 +116,30 @@ cli.parse({
   'out-file':         ['o', 'output file (default: based on path of input file); use \'\' to output to STDOUT', 'file'],
   'safe-mode':        ['S', 'set safe mode level explicitly: [unsafe, safe, server, secure] (default: unsafe)), disables potentially dangerous macros in source files, such as include::[]', 'string', 'unsafe'],
   'no-header-footer': ['s', 'suppress output of header and footer (default: false)', 'boolean', false],
-  'section-numbers':  ['n', 'auto-number section titles in the HTML backend; disabled by default', 'boolean', 'false'],
+  'section-numbers':  ['n', 'auto-number section titles in the HTML backend; disabled by default', 'boolean', false],
   'base-dir':         ['B', 'base directory containing the document and resources (default: directory of source file)', 'path'],
   'destination-dir':  ['D', 'destination output directory (default: directory of source file)', 'path'],
   'quiet':            ['q', 'suppress warnings (default: false)', 'boolean', 'false'],
-  'trace':            [false, 'include backtrace information on errors (default: false)', 'boolean', 'false'],
-  'verbose':          ['v', 'enable verbose mode (default: false)', 'boolean', 'false'],
-  'timings':          ['t', 'enable timings mode (default: false)', 'boolean', 'false'],
-  'attribute':        ['a', 'a document attribute to set in the form of key, key! or key=value pair', 'string', '']
+  'trace':            [false, 'include backtrace information on errors (default: false)', 'boolean', false],
+  'verbose':          ['v', 'enable verbose mode (default: false)', 'boolean', false],
+  'timings':          ['t', 'enable timings mode (default: false)', 'boolean', false],
+  'attribute':        ['a', 'a document attribute to set in the form of key, key! or key=value pair', 'string', ''],
+  'version':          ['V', 'display the version and runtime environment (or -v if no other flags or arguments)', 'boolean', false]
 });
 
 cli.main(function (cliArgs, cliOptions) {
   var options = convert_options(cliOptions);
-  cliArgs.forEach(function (file) {
-    var data = convert_file(file, options);
-    output_result(data, file, cliOptions);
-  });
+  var verbose = cliOptions['verbose'];
+  var version = cliOptions['version'];
+  var displayVersion = version || (verbose && cliArgs.length == 0);
+  if (displayVersion) {
+    cli.info("Asciidoctor 1.5.3 [http://asciidoctor.org]");
+    var releaseName = process.release ? process.release.name : 'node';
+    cli.info("Runtime Environment (" + releaseName + " " + process.version + " on " + process.platform + ")");
+  } else {
+    cliArgs.forEach(function (file) {
+      var data = convert_file(file, options);
+      output_result(data, file, cliOptions);
+    });
+  }
 });

--- a/bin/asciidoctorjs
+++ b/bin/asciidoctorjs
@@ -133,7 +133,7 @@ cli.main(function (cliArgs, cliOptions) {
   var version = cliOptions['version'];
   var displayVersion = version || (verbose && cliArgs.length == 0);
   if (displayVersion) {
-    cli.info("Asciidoctor 1.5.3 [http://asciidoctor.org]");
+    cli.info("Asciidoctor " + processor._scope.VERSION + " [http://asciidoctor.org]");
     var releaseName = process.release ? process.release.name : 'node';
     cli.info("Runtime Environment (" + releaseName + " " + process.version + " on " + process.platform + ")");
   } else {


### PR DESCRIPTION
```
$ asciidoctorjs --version
INFO: Asciidoctor 1.5.3 [http://asciidoctor.org]
INFO: Runtime Environment (node v0.12.0 on linux)
```
