### PR TITLE
Explain how to convert an AsciiDoc file to a reveal.js presentation.

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -1,0 +1,50 @@
+= Asciidoctor.js CLI User manual
+
+== Integration with Asciidoctor Reveal.js
+
+In this section, you'll learn:
+
+* How to install the required dependencies.
+* What attributes you must define.
+* How to convert an AsciiDoc file to a reveal.js presentation.
+
+=== Prerequisites
+
+We assume that you already have a fully working version of Asciidoctor.js CLI installed and available in your `PATH`.
+If this is not the case, please read the https://github.com/asciidoctor/asciidoctor-cli.js[installation instructions].
+
+To convert an AsciiDoc file to a reveal.js presentation, we will need to install the following module:
+
+ $ yarn add asciidoctor-reveal.js
+
+Once this module is installed, we create a file named `presentation.adoc` with the following content:
+
+.presentation.adoc 
+```adoc
+= Presentation title
+
+== First slide
+
+* Hello
+* World
+
+== Second slide
+
+With some *fascinating* content!
+```
+
+The next step is to convert this file to a reveal.js presentation using the `asciidoctorjs` command line:
+
+[source,sh]
+----
+asciidoctorjs presentation.adoc \
+  -r asciidoctor-reveal.js \ // <1>
+  -b revealjs \ // <2>
+  -a revealjsdir=node_modules/reveal.js@ // <3>
+----
+<1> Require the `asciidoctor-reveal.js` module
+<2> Use the `revealjs` backend
+<3> Specify that the reveal.js directory is located at `node_modules/reveal.js`
+
+The above command should create a file named `presentation.html`.
+Open it in a browser to view your presentation!


### PR DESCRIPTION
Resolves #18 

We are using the `--require` flag to require `asciidoctor-reveal.js` Node module: https://github.com/asciidoctor/asciidoctor-cli.js/pull/17