### PR TITLE
Add missing to_file option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,12 +66,12 @@ function convertOptions (argv) {
     options.to_dir = destinationDir
   }
   if (outFile != null) {
-    if (outFile === '') {
-      options.to_file = '-'
-    } else {
-      options.to_file = outFile
-      options.mkdirs = true
-    }
+    options.to_file = outFile
+  }
+  if (outFile === '') {
+    options.to_file = '-'
+  } else {
+    options.mkdirs = true
   }
   options.attributes = attributes
   if (verbose) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,7 +55,6 @@ function convertOptions (argv) {
     doctype: doctype,
     safe: safeMode,
     header_footer: !noHeaderFooter,
-    to_file: outFile,
     verbose: verboseMode,
     timings: timings,
     trace: trace
@@ -66,10 +65,13 @@ function convertOptions (argv) {
   if (destinationDir != null) {
     options.to_dir = destinationDir
   }
-  if (outFile === '') {
-    options.to_file = '-'
-  } else {
-    options.mkdirs = true
+  if (outFile != null) {
+    if (outFile === '') {
+      options.to_file = '-'
+    } else {
+      options.to_file = outFile
+      options.mkdirs = true
+    }
   }
   options.attributes = attributes
   if (verbose) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -65,11 +65,13 @@ function convertOptions (argv) {
   if (destinationDir != null) {
     options.to_dir = destinationDir
   }
-  if (outFile != null) {
-    options.to_file = outFile
-  }
-  if (outFile === '') {
-    options.to_file = '-'
+  if (outFile) {
+    if (outFile === '') {
+      options.to_file = '-'
+    } else {
+      options.to_file = outFile
+      options.mkdirs = true
+    }
   } else {
     options.mkdirs = true
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,6 +55,7 @@ function convertOptions (argv) {
     doctype: doctype,
     safe: safeMode,
     header_footer: !noHeaderFooter,
+    to_file: outFile,
     verbose: verboseMode,
     timings: timings,
     trace: trace


### PR DESCRIPTION
Looks like `options.to_file` is never set except for the `stdout` case.
As a result, even if an output path is specified, the html file is created in the same directory
and with the same name of the original `.adoc` file.