### PR TITLE
Resolves #37, add the CLI version and the Asciidoctor.js version

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 
 const yargs = require('yargs')
 const asciidoctor = require('asciidoctor.js')()
+const pkg = require('../package.json')
 
 function convertOptions (argv) {
   const backend = argv['backend']
@@ -180,6 +181,7 @@ function argsParser () {
           type: 'boolean'
         })
     })
+    .version(false)
     .help()
 }
 
@@ -189,9 +191,10 @@ function run (argv) {
   const files = argv['files']
   const options = convertOptions(argv)
   if (version || (verbose && files && files.length === 0)) {
-    console.log(`Asciidoctor ${asciidoctor.getCoreVersion()} [http://asciidoctor.org]`)
+    console.log(`Asciidoctor.js ${asciidoctor.getVersion()} [https://asciidoctor.org]`)
     const releaseName = process.release ? process.release.name : 'node'
     console.log(`Runtime Environment (${releaseName} ${process.version} on ${process.platform})`)
+    console.log(`CLI version ${pkg.version}`)
   } else if (files && files.length > 0) {
     files.forEach(function (file) {
       if (verbose) {


### PR DESCRIPTION
```
CLI version 1.5.6-rc.1
Asciidoctor.js 1.5.9 (built using Asciidoctor 1.5.8) [https://asciidoctor.org]
Runtime Environment (node v8.11.1 on linux)
```

Should we keep `(built using Asciidoctor 1.5.8)` ?
I think the CLI version is important but maybe it's confusing ?

**[EDIT]**

What about:

```
asciidoctorjs version 1.5.6-rc.1
Asciidoctor.js 1.5.9 [https://asciidoctor.org]
Runtime Environment (Asciidoctor 1.5.8)(node v8.11.1 on linux)