### PR TITLE
resolves #35 automatically register converter and extension

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,10 +3,12 @@
 
 const yargs = require('yargs')
 const fs = require('fs')
-const path = require('path')
+const ospath = require('path')
 const asciidoctor = require('@asciidoctor/core')()
 const pkg = require('../package.json')
 const stdin = require('./stdin')
+
+const DOT_RELATIVE_RX = new RegExp(`^\\.{1,2}[/${ospath.sep.replace('/', '').replace('\\', '\\\\')}]`)
 
 function convertOptions (args) {
   const backend = args['backend']
@@ -45,9 +47,6 @@ function convertOptions (args) {
     console.log('trace ' + trace)
     console.log('base-dir ' + baseDir)
     console.log('destination-dir ' + destinationDir)
-  }
-  if (requireLib) {
-    require(requireLib)
   }
   const verboseMode = quiet ? 0 : verbose ? 2 : 1
   const attributes = []
@@ -271,6 +270,34 @@ function processFiles (files, verbose, timings, options) {
   process.exit(code)
 }
 
+function requireLibrary (requirePath, cwd = process.cwd()) {
+  if (requirePath.charAt(0) === '.' && DOT_RELATIVE_RX.test(requirePath)) {
+    // NOTE require resolves a dot-relative path relative to current file; resolve relative to cwd instead
+    requirePath = ospath.resolve(requirePath)
+  } else if (!ospath.isAbsolute(requirePath)) {
+    // NOTE appending node_modules prevents require from looking elsewhere before looking in these paths
+    const paths = [cwd, ospath.dirname(__dirname)].map((start) => ospath.join(start, 'node_modules'))
+    requirePath = require.resolve(requirePath, { paths })
+  }
+  return require(requirePath)
+}
+
+function prepareProcessor (argv, asciidoctor) {
+  const requirePaths = argv['require']
+  if (requirePaths) {
+    requirePaths.forEach(function (requirePath) {
+      const lib = requireLibrary(requirePath)
+      if (lib && typeof lib.register === 'function') {
+        // REMIND: it could be an extension or a converter.
+        // the register function on a converter does not take any argument
+        // but the register function on an extension expects one argument (the extension registry)
+        // Until we revisit the API for extension and converter, we pass the registry as the first argument
+        lib.register(asciidoctor.Extensions)
+      }
+    })
+  }
+}
+
 function run (argv) {
   const processArgs = argv.slice(2)
   const args = argsParser().parse(processArgs)
@@ -282,6 +309,7 @@ function run (argv) {
     args['out-file'] = args['out-file'] || '-'
   }
   const options = convertOptions(args)
+  prepareProcessor(args, asciidoctor)
   if (stdin) {
     convertFromStdin(options, args)
   } else if (version || (verbose && files && files.length === 0)) {
@@ -293,7 +321,7 @@ function run (argv) {
     processFiles(files, verbose, args['timings'], options)
   } else {
     if (args['help'] === 'syntax') {
-      console.log(fs.readFileSync(path.join(__dirname, '..', 'data', 'reference', 'syntax.adoc'), 'utf8'))
+      console.log(fs.readFileSync(ospath.join(__dirname, '..', 'data', 'reference', 'syntax.adoc'), 'utf8'))
     } else {
       yargs.showHelp()
     }
@@ -305,5 +333,6 @@ module.exports = {
   argsParser: argsParser,
   convertOptions: convertOptions,
   processFiles: processFiles,
-  processor: asciidoctor
+  processor: asciidoctor,
+  prepareProcessor: prepareProcessor
 }

--- a/test/fixtures/blog-converter.js
+++ b/test/fixtures/blog-converter.js
@@ -1,0 +1,9 @@
+class BlogConverter {
+  convert () {
+    return '<blog></blog>';
+  }
+}
+
+module.exports.register = function register () {
+  Opal.Asciidoctor.ConverterFactory.register(new BlogConverter(), ['blog']);
+}

--- a/test/fixtures/shout-ext.js
+++ b/test/fixtures/shout-ext.js
@@ -1,0 +1,20 @@
+const shoutBlock = function () {
+  const self = this
+  self.named('shout')
+  self.onContext('paragraph')
+  self.process(function (parent, reader) {
+    const lines = reader.getLines().map(l => l.toUpperCase())
+    return self.createBlock(parent, 'paragraph', lines)
+  })
+}
+
+module.exports.register = function register (registry) {
+  if (typeof registry.register === 'function') {
+    registry.register(function () {
+      this.block(shoutBlock)
+    })
+  } else if (typeof registry.block === 'function') {
+    registry.block(shoutBlock)
+  }
+  return registry
+}


### PR DESCRIPTION
We've already discussed this issue with @mojavelinux but I think we should try to automatically register converters and extensions using a well defined API.

As mentioned in the code, currently we have a "conflict" in the API. Both converters and extensions are using the `register` function. But the `register` function used in extensions expects one argument (the extension registry) while the `register` function used in converters does not take any argument.