### PR TITLE
Resolves #42, suggest to require a Node.js package if the backend is not found

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -185,6 +185,19 @@ function argsParser () {
     .help()
 }
 
+function convertFile (file, options) {
+  try {
+    asciidoctor.convertFile(file, options)
+  } catch (e) {
+    if (e && e.name === 'NotImplementedError' && e.message === `asciidoctor: FAILED: missing converter for backend '${options.backend}'. Processing aborted.`) {
+      console.error(`> Error: missing converter for backend '${options.backend}'. Processing aborted.`)
+      console.error(`> You might want to require a Node.js package with --require option to support this backend.`)
+      process.exit(1)
+    }
+    throw e
+  }
+}
+
 function run (argv) {
   const verbose = argv['verbose']
   const version = argv['version']
@@ -203,10 +216,10 @@ function run (argv) {
       if (argv['timings']) {
         const timings = asciidoctor.Timings.$new()
         const instanceOptions = Object.assign({}, options, { timings: timings })
-        asciidoctor.convertFile(file, instanceOptions)
+        convertFile(file, instanceOptions)
         timings.$print_report(Opal.gvars.stderr, file)
       } else {
-        asciidoctor.convertFile(file, options)
+        convertFile(file, options)
       }
     })
   } else {


### PR DESCRIPTION

#### Before

```
$ ./bin/asciidoctorjs -b blog README.adoc                                                       
```
```
/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:19584
          } else { throw $err; }
                   ^
NotImplementedError: asciidoctor: FAILED: missing converter for backend 'blog'. Processing aborted.
    at Opal.send (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/opal-runtime/src/opal.js:1660:19)
    at Function.$$exception (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/opal-runtime/src/opal.js:5519:14)
    at $Document.$$raise (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/opal-runtime/src/opal.js:5204:31)
    at $Document.$$update_backend_attributes (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:8046:18)
    at $Document.$$initialize (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:7278:16)
    at Object.Opal.send (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/opal-runtime/src/opal.js:1660:19)
    at Function.TMP_Class_new_5 (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/opal-runtime/src/opal.js:3608:12)
    at /home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:19550:45
    at Function.$$load (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:19551:28)
    at Function.$$convert (/home/guillaume/workspace/opensource/asciidoctor/asciidoctor-cli.js/node_modules/asciidoctor.js/dist/node/asciidoctor.js:19673:20)
```

#### After


```
$ ./bin/asciidoctorjs -b blog README.adoc
```
```
> Error: missing converter for backend 'blog'. Processing aborted.
> You might want to require a Node.js package with --require option to support this backend.
```