### PR TITLE
resolves #50 read from stdin + add help syntax

### DIFF
--- a/bin/asciidoctor
+++ b/bin/asciidoctor
@@ -4,5 +4,4 @@
 
 process.title = 'asciidoctor'
 const cli = require('../lib/cli.js')
-const argv = cli.argsParser().argv
-cli.run(argv)
+cli.run(process.argv)

--- a/data/reference/syntax.adoc
+++ b/data/reference/syntax.adoc
@@ -1,0 +1,289 @@
+= AsciiDoc Syntax
+:icons: font
+:stem:
+:toc: left
+:url-docs: https://asciidoctor.org/docs
+:url-gem: https://rubygems.org/gems/asciidoctor
+
+A brief reference of the most commonly used AsciiDoc syntax.
+You can find the full documentation for the AsciiDoc syntax at {url-docs}.
+
+== Paragraphs
+
+A normal paragraph.
+Line breaks are not preserved.
+// line comments, which are lines that start with //, are skipped
+
+A blank line separates paragraphs.
+
+[%hardbreaks]
+This paragraph carries the `hardbreaks` option.
+Notice how line breaks are now preserved.
+
+ An indented (literal) paragraph disables text formatting,
+ preserves spaces and line breaks, and is displayed in a
+ monospaced font.
+
+[sidebar#id.role]
+A style, ID, and/or role gives a paragraph (or block) special meaning, like this sidebar.
+
+NOTE: An admonition paragraph, like this note, grabs the reader's attention.
+
+TIP: Convert this document using the `asciidoctor` command to see the output produced from it.
+
+== Text Formatting
+:hardbreaks:
+
+.Constrained (applied at word boundaries)
+*strong importance* (aka bold)
+_stress emphasis_ (aka italic)
+`monospaced` (aka typewriter text)
+"`double`" and '`single`' typographic quotes
++passthrough text+ (substitutions disabled)
+`+literal text+` (monospaced with substitutions disabled)
+
+.Unconstrained (applied anywhere)
+**C**reate+**R**ead+**U**pdate+**D**elete
+fan__freakin__tastic
+``mono``culture
+
+.Replacements
+A long time ago in a galaxy far, far away...
+(C) 1976 Arty Artisan
+I believe I shall--no, actually I won't.
+
+.Macros
+// where c=specialchars, q=quotes, a=attributes, r=replacements, m=macros, p=post_replacements, etc.
+The European icon:flag[role=blue] is blue & contains pass:[************] arranged in a icon:circle-o[role=yellow].
+The pass:c[->] operator is often referred to as the stabby lambda.
+Since `pass:[++]` has strong priority in AsciiDoc, you can rewrite pass:c,a,r[C++ => C{pp}].
+// activate stem support by adding `:stem:` to the document header
+stem:[sqrt(4) = 2]
+
+:!hardbreaks:
+== Attributes
+
+ // define attributes in the document header; must be flush with left margin
+ :name: value
+
+You can download and install Asciidoctor {asciidoctor-version} from {url-gem}.
+C{pp} is not required, only Ruby.
+Use a leading backslash to output a word enclosed in curly braces, like \{name}.
+
+== Links
+
+[%hardbreaks]
+https://example.org/page[A webpage]
+link:../path/to/file.txt[A local file]
+xref:document.adoc[A sibling document]
+mailto:hello@example.org[Email to say hello!]
+
+== Anchors
+
+[[idname,reference text]]
+// or written using normal block attributes as `[#idname,reftext=reference text]`
+A paragraph (or any block) with an anchor (aka ID) and reftext.
+
+See <<idname>> or <<idname,optional text of internal link>>.
+
+xref:document.adoc#idname[Jumps to anchor in another document].
+
+This paragraph has a footnote.footnote:[This is the text of the footnote.]
+
+== Lists
+
+=== Unordered
+
+* level 1
+** level 2
+*** level 3
+**** level 4
+***** etc.
+* back at level 1
++
+Attach a block or paragraph to a list item using a list continuation (which you can enclose in an open block).
+
+.Some Authors
+[circle]
+- Edgar Allen Poe
+- Sheri S. Tepper
+- Bill Bryson
+
+=== Ordered
+
+. Step 1
+. Step 2
+.. Step 2a
+.. Step 2b
+. Step 3
+
+.Remember your Roman numerals?
+[upperroman]
+. is one
+. is two
+. is three
+
+=== Checklist
+
+* [x] checked
+* [ ] not checked
+
+=== Callout
+
+// enable callout bubbles by adding `:icons: font` to the document header
+[,ruby]
+----
+puts 'Hello, World!' # <1>
+----
+<1> Prints `Hello, World!` to the console.
+
+=== Description
+
+first term:: description of first term
+second term::
+description of second term
+
+== Document Structure
+
+=== Header
+
+ // header must be flush with left margin
+ = Document Title
+ Author Name <author@example.org>
+ v1.0, 2019-01-01
+
+=== Sections
+
+ // must be flush with left margin
+ = Document Title (Level 0)
+ == Level 1
+ === Level 2
+ ==== Level 3
+ ===== Level 4
+ ====== Level 5
+ == Back at Level 1
+
+=== Includes
+
+ // must be flush with left margin
+ include::basics.adoc[]
+
+ // define -a allow-uri-read to allow content to be read from URI
+ include::https://example.org/installation.adoc[]
+
+== Blocks
+
+--
+open - a general-purpose content wrapper; useful for enclosing content to attach to a list item
+--
+
+// recognized types include CAUTION, IMPORTANT, NOTE, TIP, and WARNING
+// enable admonition icons by setting `:icons: font` in the document header
+[NOTE]
+====
+admonition - a notice for the reader, ranging in severity from a tip to an alert
+====
+
+====
+example - a demonstration of the concept being documented
+====
+
+.Toggle Me
+[%collapsible]
+====
+collapsible - these details are revealed by clicking the title
+====
+
+****
+sidebar - auxiliary content that can be read independently of the main content
+****
+
+....
+literal - an exhibit that features program output
+....
+
+----
+listing - an exhibit that features program input, source code, or the contents of a file
+----
+
+[,language]
+----
+source - a listing that is embellished with (colorized) syntax highlighting
+----
+
+```language
+fenced code - a shorthand syntax for the source block
+```
+
+[,attribution,citetitle]
+____
+quote - a quotation or excerpt; attribution with title of source are optional
+____
+
+[verse,attribution,citetitle]
+____
+verse - a literary excerpt, often a poem; attribution with title of source are optional
+____
+
+++++
+pass - content passed directly to the output document; often raw HTML
+++++
+
+// activate stem support by adding `:stem:` to the document header
+[stem]
+++++
+x = y^2
+++++
+
+////
+comment - content which is not included in the output document
+////
+
+== Tables
+
+.Table Attributes
+[cols=>1h;2d,width=50%,frame=topbot]
+|===
+| Attribute Name | Values
+
+| options
+| header,footer,autowidth
+
+| cols
+| colspec[;colspec;...]
+
+| grid
+| all \| cols \| rows \| none
+
+| frame
+| all \| sides \| topbot \| none
+
+| stripes
+| all \| even \| odd \| none
+
+| width
+| (0%..100%)
+
+| format
+| psv {vbar} csv {vbar} dsv
+|===
+
+== Multimedia
+
+image::screenshot.png[block image,800,450]
+
+Press image:reload.svg[reload,16,opts=interactive] to reload the page.
+
+video::movie.mp4[width=640,start=60,end=140,options=autoplay]
+
+video::aHjpOzsQ9YI[youtube]
+
+video::300817511[vimeo]
+
+== Breaks
+
+// thematic break (aka horizontal rule)
+---
+
+// page break
+<<<

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,27 +2,30 @@
 'use strict'
 
 const yargs = require('yargs')
+const fs = require('fs')
+const path = require('path')
 const asciidoctor = require('@asciidoctor/core')()
 const pkg = require('../package.json')
+const stdin = require('./stdin')
 
-function convertOptions (argv) {
-  const backend = argv['backend']
-  const doctype = argv['doctype']
-  const safeMode = argv['safe-mode']
+function convertOptions (args) {
+  const backend = args['backend']
+  const doctype = args['doctype']
+  const safeMode = args['safe-mode']
   // "--no-header-footer" is translated to header-footer = false but the alias "-s" is translated to no-header-footer = true
-  const noHeaderFooter = argv['header-footer'] === false || argv['no-header-footer'] === true
-  const embedded = argv['embedded'] === true
-  const sectionNumbers = argv['section-numbers']
-  const baseDir = argv['base-dir']
-  const destinationDir = argv['destination-dir']
-  const outFile = argv['out-file']
-  const quiet = argv['quiet']
-  const verbose = argv['verbose']
-  const timings = argv['timings']
-  const trace = argv['trace']
-  const requireLib = argv['require']
+  const noHeaderFooter = args['header-footer'] === false || args['no-header-footer'] === true
+  const embedded = args['embedded'] === true
+  const sectionNumbers = args['section-numbers']
+  const baseDir = args['base-dir']
+  const destinationDir = args['destination-dir']
+  const outFile = args['out-file']
+  const quiet = args['quiet']
+  const verbose = args['verbose']
+  const timings = args['timings']
+  const trace = args['trace']
+  const requireLib = args['require']
   const standalone = !(noHeaderFooter === true || embedded === true)
-  let level = argv['failure-level'].toUpperCase()
+  let level = args['failure-level'].toUpperCase()
   if (level === 'WARNING') {
     level = 'WARN'
   }
@@ -51,7 +54,7 @@ function convertOptions (argv) {
   if (sectionNumbers) {
     attributes.push('sectnums')
   }
-  const cliAttributes = argv['attribute']
+  const cliAttributes = args['attribute']
   if (cliAttributes) {
     attributes.push(...cliAttributes)
   }
@@ -200,14 +203,38 @@ function argsParser () {
           describe: 'display the version and runtime environment (or -v if no other flags or arguments)',
           type: 'boolean'
         })
+        .option('help', {
+          describe: `print a help message
+show this usage if TOPIC is not specified or recognized
+show an overview of the AsciiDoc syntax if TOPIC is syntax`,
+          type: 'string'
+        })
+        .usage(`$0 [options...] files...
+Translate the AsciiDoc source file or file(s) into the backend output format (e.g., HTML 5, DocBook 5, etc.)
+By default, the output is written to a file with the basename of the source file and the appropriate extension`)
+        .example('$0 -b html5 doc.asciidoc', 'convert an AsciiDoc file to HTML5; result will be written in a file named doc.html')
+        .epilogue('For more information, please visit https://asciidoctor.org/docs')
     })
     .version(false)
-    .help()
+    .help(false)
 }
 
-function convertFile (file, options) {
+function convertFromStdin (options, args) {
+  stdin.read((data) => {
+    if (args['timings']) {
+      const timings = asciidoctor.Timings.$new()
+      const instanceOptions = Object.assign({}, options, { timings: timings })
+      convert(asciidoctor.convert, data, instanceOptions)
+      timings.$print_report(Opal.gvars.stderr, '-')
+    } else {
+      convert(asciidoctor.convert, data, options)
+    }
+  })
+}
+
+function convert (processorFn, input, options) {
   try {
-    asciidoctor.convertFile(file, options)
+    processorFn.apply(asciidoctor, [input, options])
   } catch (e) {
     if (e && e.name === 'NotImplementedError' && e.message === `asciidoctor: FAILED: missing converter for backend '${options.backend}'. Processing aborted.`) {
       console.error(`> Error: missing converter for backend '${options.backend}'. Processing aborted.`)
@@ -216,6 +243,10 @@ function convertFile (file, options) {
     }
     throw e
   }
+}
+
+function convertFile (file, options) {
+  convert(asciidoctor.convertFile, file, options)
 }
 
 function processFiles (files, verbose, timings, options) {
@@ -241,19 +272,31 @@ function processFiles (files, verbose, timings, options) {
 }
 
 function run (argv) {
-  const verbose = argv['verbose']
-  const version = argv['version']
-  const files = argv['files']
-  const options = convertOptions(argv)
-  if (version || (verbose && files && files.length === 0)) {
+  const processArgs = argv.slice(2)
+  const args = argsParser().parse(processArgs)
+  const verbose = args['verbose']
+  const version = args['version']
+  const files = args['files']
+  const stdin = files && files.length === 0 && processArgs[processArgs.length - 1] === '-'
+  if (stdin) {
+    args['out-file'] = args['out-file'] || '-'
+  }
+  const options = convertOptions(args)
+  if (stdin) {
+    convertFromStdin(options, args)
+  } else if (version || (verbose && files && files.length === 0)) {
     console.log(`Asciidoctor.js ${asciidoctor.getVersion()} [https://asciidoctor.org]`)
     const releaseName = process.release ? process.release.name : 'node'
     console.log(`Runtime Environment (${releaseName} ${process.version} on ${process.platform})`)
     console.log(`CLI version ${pkg.version}`)
   } else if (files && files.length > 0) {
-    processFiles(files, verbose, argv['timings'], options)
+    processFiles(files, verbose, args['timings'], options)
   } else {
-    yargs.showHelp()
+    if (args['help'] === 'syntax') {
+      console.log(fs.readFileSync(path.join(__dirname, '..', 'data', 'reference', 'syntax.adoc'), 'utf8'))
+    } else {
+      yargs.showHelp()
+    }
   }
 }
 
@@ -261,5 +304,6 @@ module.exports = {
   run: run,
   argsParser: argsParser,
   convertOptions: convertOptions,
-  processFiles: processFiles
+  processFiles: processFiles,
+  processor: asciidoctor
 }

--- a/lib/stdin.js
+++ b/lib/stdin.js
@@ -1,0 +1,21 @@
+const readFromStdin = (callback) => {
+  const encoding = 'utf-8'
+  let data
+  data = ''
+  process.stdin.setEncoding(encoding)
+  process.stdin.on('readable', function () {
+    const chunk = process.stdin.read()
+    if (chunk !== null) {
+      data += chunk
+    }
+  })
+  process.stdin.on('end', function () {
+    // There will be a trailing \n from the user hitting enter. Get rid of it.
+    data = data.replace(/\n$/, '')
+    callback(data)
+  })
+}
+
+module.exports = {
+  read: readFromStdin
+}


### PR DESCRIPTION
This pull request introduces two features at once:

1. Read from stdin
2. Add --help syntax

The following is now supported:

```
$ asciidoctor --help syntax | asciidoctor -
```

:tada: 

