### PR TITLE
Disable boolean negation

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -7,8 +7,7 @@ const convertOptions = (args, attrs) => {
   const backend = args['backend']
   const doctype = args['doctype']
   const safeMode = args['safe-mode']
-  // "--no-header-footer" is translated to header-footer = false but the alias "-s" is translated to no-header-footer = true
-  const embedded = args['embedded'] === true || args['header-footer'] === false || args['no-header-footer'] === true || args['standalone'] === false
+  const embedded = args['embedded'] === true || args['no-header-footer'] === true || args['standalone'] === false
   const standalone = !embedded
   const sectionNumbers = args['section-numbers']
   const baseDir = args['base-dir']
@@ -248,6 +247,9 @@ By default, the output is written to a file with the basename of the source file
       .command('$0 [files...]', '', () => this.cmd)
       .version(false)
       .help(false)
+      .parserConfiguration({
+        'boolean-negation': false
+      })
   }
 }
 


### PR DESCRIPTION
In some cases it doesn't make sense, so we are using the `--no-` prefix explicitly when it does.